### PR TITLE
Update modules for latest CVE report

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,10 +28,10 @@ require (
 	go.uber.org/atomic v1.6.0 // indirect
 	go.uber.org/multierr v1.5.0 // indirect
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
-	golang.org/x/net v0.0.0-20200904194848-62affa334b73 // indirect
-	golang.org/x/sys v0.0.0-20200828194041-157a740278f4 // indirect
-	golang.org/x/text v0.3.3 // indirect
-	golang.org/x/tools v0.0.0-20200915173823-2db8f0ff891c // indirect
+	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/text v0.9.0 // indirect
+	golang.org/x/tools v0.6.0 // indirect
 	gopkg.in/ini.v1 v1.51.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.4 // indirect


### PR DESCRIPTION
ref: https://github.com/outdoorsafetylab/geoipd/security/dependabot

golang.org/x/net v0.0.0-20200904194848-62affa334b73 -> v0.10.0
golang.org/x/sys v0.0.0-20200828194041-157a740278f4 -> v0.8.0
golang.org/x/text v0.3.3 -> v0.9.0
golang.org/x/tools v0.0.0-20200915173823-2db8f0ff891c -> v0.6.0
